### PR TITLE
Grouped apt-get update and install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,8 @@ FROM ubuntu
 # Set the file maintainer (your name - the file's author)
 MAINTAINER Borja Burgos <borja@tutum.co>
 
-# Update the default application repository sources list
-RUN apt-get update
-
 # Install Memcached
-RUN apt-get install -y memcached
+RUN apt-get update && apt-get install -y memcached
 
 # Port to expose (default: 11211)
 EXPOSE 11211


### PR DESCRIPTION
See http://crosbymichael.com/dockerfile-best-practices-take-2.html

Also I recommend configuring the base image (`ubuntu` in this case) as a linked repository:
- Go to https://hub.docker.com/r/borja/docker-memcached/~/settings/automated-builds/
- Scroll to section _Repository Links_
- Add ubuntu

This way the docker hub will rebuild the image every time the ubuntu repository get updated.
